### PR TITLE
Allow host to be set in options

### DIFF
--- a/lib/remote-atom.coffee
+++ b/lib/remote-atom.coffee
@@ -162,7 +162,7 @@ module.exports =
             default: 52698
         host:
             type: 'string'
-            default: 'localhost',
+            default: '0.0.0.0',
     server_is_running: false
 
     activate: (state) ->

--- a/lib/remote-atom.coffee
+++ b/lib/remote-atom.coffee
@@ -159,7 +159,10 @@ module.exports =
             default: false
         port:
             type: 'integer'
-            default: 52698,
+            default: 52698
+        host:
+            type: 'string'
+            default: 'localhost',
     server_is_running: false
 
     activate: (state) ->
@@ -187,9 +190,10 @@ module.exports =
             session = new Session(socket)
 
         port = atom.config.get "remote-atom.port"
+        host = atom.config.get "remote-atom.host"
         @server.on 'listening', (e) =>
             @server_is_running = true
-            console.log "[ratom] listening on port #{port}"
+            console.log "[ratom] listening on #{host}:#{port}"
 
         @server.on 'error', (e) =>
             if not quiet
@@ -204,7 +208,7 @@ module.exports =
         @server.on "close", () ->
             console.log "[ratom] stop server"
 
-        @server.listen port, '0.0.0.0'
+        @server.listen port, host
 
     stop_server: ->
         status-message.display "Stopping remote atom server", 2000


### PR DESCRIPTION
Hi there,
Fist of all, thank you for this very useful plugin which comes in handy almost every day for me.
Recently I have been setting up my tunnel to atom via a VPN, and wanted to make sure the rmate plugin was only listening on the VPN interface. I realized there was no option to do so, but that it was very simple to implement, so here it is for your consideration.
Best regards,
Mark.